### PR TITLE
Add DomainAgent skeleton for Namecheap

### DIFF
--- a/forge_domains/README.md
+++ b/forge_domains/README.md
@@ -1,0 +1,18 @@
+# Forge Domains
+
+The `forge_domains` package provides tooling to automate DNS record management for AT Protocol domain handles. It currently includes a skeleton `DomainAgent` that integrates with the Namecheap API for creating and verifying `_atproto` TXT records.
+
+## Usage
+
+Set the following environment variables:
+
+- `NAMECHEAP_API_USER` – Namecheap API username
+- `NAMECHEAP_API_KEY` – Namecheap API key
+- `NAMECHEAP_CLIENT_IP` – The whitelisted client IP for Namecheap API access
+- `NAMECHEAP_USERNAME` – (optional) Namecheap account username if different from `NAMECHEAP_API_USER`
+
+```bash
+python forge_domains/domain_agent.py yourdomain.com did:plc:example
+```
+
+This will attempt to create or update the `_atproto` TXT record for `yourdomain.com` with the specified DID and poll DNS until the record is visible.

--- a/forge_domains/domain_agent.py
+++ b/forge_domains/domain_agent.py
@@ -1,0 +1,72 @@
+import os
+import requests
+import time
+import dns.resolver
+from urllib.parse import urlencode
+
+class DomainAgent:
+    NAMECHEAP_API_URL = "https://api.namecheap.com/xml.response"
+
+    def __init__(self, api_user=None, api_key=None, client_ip=None, username=None):
+        self.api_user = api_user or os.getenv("NAMECHEAP_API_USER")
+        self.api_key = api_key or os.getenv("NAMECHEAP_API_KEY")
+        self.client_ip = client_ip or os.getenv("NAMECHEAP_CLIENT_IP")
+        self.username = username or os.getenv("NAMECHEAP_USERNAME", self.api_user)
+        if not all([self.api_user, self.api_key, self.client_ip]):
+            raise ValueError("Missing Namecheap API credentials")
+
+    def _request(self, command, params):
+        query = {
+            "ApiUser": self.api_user,
+            "ApiKey": self.api_key,
+            "UserName": self.username,
+            "ClientIp": self.client_ip,
+            "Command": command,
+            **params,
+        }
+        response = requests.get(self.NAMECHEAP_API_URL, params=query)
+        response.raise_for_status()
+        return response.text
+
+    def set_txt_record(self, domain, host, value, ttl=60):
+        return self._request(
+            "namecheap.domains.dns.setHosts",
+            {
+                "SLD": domain.split(".")[0],
+                "TLD": domain.split(".")[1],
+                "HostName1": host,
+                "RecordType1": "TXT",
+                "Address1": value,
+                "TTL1": ttl,
+            },
+        )
+
+    def verify_dns(self, fqdn, expected_value, timeout=300):
+        end_time = time.time() + timeout
+        while time.time() < end_time:
+            try:
+                answers = dns.resolver.resolve(fqdn, "TXT")
+                for rdata in answers:
+                    if expected_value in str(rdata.strings[0], "utf-8"):
+                        return True
+            except Exception:
+                pass
+            time.sleep(30)
+        return False
+
+if __name__ == "__main__":
+    import sys
+
+    if len(sys.argv) != 3:
+        print("Usage: domain_agent.py <domain> <did>")
+        sys.exit(1)
+
+    domain, did = sys.argv[1], sys.argv[2]
+    agent = DomainAgent()
+    agent.set_txt_record(domain, "_atproto", f"did={did}")
+    fqdn = f"_atproto.{domain}"
+    if agent.verify_dns(fqdn, f"did={did}"):
+        print(f"{domain} verified for {did}")
+    else:
+        print("Verification timed out")
+        sys.exit(1)

--- a/forge_domains/requirements.txt
+++ b/forge_domains/requirements.txt
@@ -1,0 +1,2 @@
+requests
+dnspython


### PR DESCRIPTION
## Summary
- start `forge_domains` package
- add skeleton DomainAgent to manage _atproto DNS TXT records via the Namecheap API
- document environment variables and basic usage

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_b_68471a1ce67c83278e3301ce5b86febf